### PR TITLE
aspnetcore30: Update ASPNETCORE and Orleans 3.0.0

### DIFF
--- a/Orleans.Streams.RabbitMqStreamProvider.Tests/Orleans.Streams.RabbitMqStreamProvider.Tests.csproj
+++ b/Orleans.Streams.RabbitMqStreamProvider.Tests/Orleans.Streams.RabbitMqStreamProvider.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -11,19 +11,16 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="2.4.3">
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.Core" Version="2.4.3" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator" Version="2.4.3" />
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.4.3" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.4.3" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="2.4.3" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="3.0.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="protobuf-net" Version="2.4.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.2" />
     <PackageReference Include="ToxiproxyNetCore" Version="1.0.2" />
   </ItemGroup>
 

--- a/Orleans.Streams.RabbitMqStreamProvider.Tests/TestCluster.cs
+++ b/Orleans.Streams.RabbitMqStreamProvider.Tests/TestCluster.cs
@@ -67,7 +67,6 @@ namespace RabbitMqStreamTests
                 .UseLocalhostClustering(siloPort: 11111, gatewayPort: 30000)
                 .Configure<ClusterMembershipOptions>(options =>
                 {
-                    options.ExpectedClusterSize = 2;
                     options.UseLivenessGossip = true;
                     options.ProbeTimeout = TimeSpan.FromSeconds(5);
                     options.NumMissedProbesLimit = 3;
@@ -80,7 +79,6 @@ namespace RabbitMqStreamTests
                     primarySiloEndpoint: new IPEndPoint(IPAddress.Loopback, EndpointOptions.DEFAULT_SILO_PORT))
                 .Configure<ClusterMembershipOptions>(options =>
                 {
-                    options.ExpectedClusterSize = 2;
                     options.UseLivenessGossip = true;
                     options.ProbeTimeout = TimeSpan.FromSeconds(5);
                     options.NumMissedProbesLimit = 3;

--- a/Orleans.Streams.RabbitMqStreamProvider/Orleans.Streams.RabbitMqStreamProvider.csproj
+++ b/Orleans.Streams.RabbitMqStreamProvider/Orleans.Streams.RabbitMqStreamProvider.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.4.3" />
+    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="3.0.0" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.2" />
   </ItemGroup>
 

--- a/Orleans.Streams.RabbitMqStreamProvider/RabbitMqStreamBuilder.cs
+++ b/Orleans.Streams.RabbitMqStreamProvider/RabbitMqStreamBuilder.cs
@@ -1,17 +1,19 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Configuration;
+using Orleans.Hosting;
 using Orleans.Streams;
 using Orleans.Streams.BatchContainer;
 
 namespace Orleans.Streaming
 {
-    public class SiloRabbitMqStreamConfigurator<TSerializer> : SiloPersistentStreamConfigurator where TSerializer : IBatchContainerSerializer, new()
+    public class SiloRabbitMqStreamConfigurator<TSerializer> : SiloPersistentStreamConfigurator
+        where TSerializer : IBatchContainerSerializer, new()
     {
         public SiloRabbitMqStreamConfigurator(string name, Action<Action<IServiceCollection>> configureDelegate)
             : base(name, configureDelegate, RabbitMqAdapterFactory<TSerializer>.Create)
         {
-            this.configureDelegate(services =>
+            ConfigureDelegate(services =>
                 {
                     services.ConfigureNamedOptionForLogging<RabbitMqOptions>(name)
                         .AddTransient<IConfigurationValidator>(sp => new RabbitMqOptionsValidator(sp.GetOptionsByName<RabbitMqOptions>(name), name))
@@ -22,7 +24,7 @@ namespace Orleans.Streaming
 
         public SiloRabbitMqStreamConfigurator<TSerializer> ConfigureRabbitMq(string host, int port, string virtualHost, string user, string password, string queueName, bool useQueuePartitioning = RabbitMqOptions.DefaultUseQueuePartitioning, int numberOfQueues = RabbitMqOptions.DefaultNumberOfQueues)
         {
-            Configure<RabbitMqOptions>(ob => ob.Configure(options =>
+            this.Configure<RabbitMqOptions>(ob => ob.Configure(options =>
                 {
                     options.HostName = host;
                     options.Port = port;
@@ -38,13 +40,13 @@ namespace Orleans.Streaming
 
         public SiloRabbitMqStreamConfigurator<TSerializer> ConfigureCache(int cacheSize)
         {
-            Configure<CachingOptions>(ob => ob.Configure(options => options.CacheSize = cacheSize));
+            this.Configure<CachingOptions>(ob => ob.Configure(options => options.CacheSize = cacheSize));
             return this;
         }
 
         public SiloRabbitMqStreamConfigurator<TSerializer> ConfigureCache(int cacheSize, TimeSpan cacheFillingTimeout)
         {
-            Configure<CachingOptions>(ob => ob.Configure(options =>
+            this.Configure<CachingOptions>(ob => ob.Configure(options =>
                 {
                     options.CacheSize = cacheSize;
                     options.CacheFillingTimeout = cacheFillingTimeout;
@@ -53,12 +55,13 @@ namespace Orleans.Streaming
         }
     }
 
-    public class ClusterClientRabbitMqStreamConfigurator<TSerializer> : ClusterClientPersistentStreamConfigurator where TSerializer : IBatchContainerSerializer, new()
+    public class ClusterClientRabbitMqStreamConfigurator<TSerializer> : ClusterClientPersistentStreamConfigurator
+        where TSerializer : IBatchContainerSerializer, new()
     {
         public ClusterClientRabbitMqStreamConfigurator(string name, IClientBuilder builder)
             : base(name, builder, RabbitMqAdapterFactory<TSerializer>.Create)
         {
-            clientBuilder
+            builder
                 .ConfigureApplicationParts(parts => parts.AddFrameworkPart(typeof(RabbitMqAdapterFactory<TSerializer>).Assembly))
                 .ConfigureServices(services => services
                     .ConfigureNamedOptionForLogging<RabbitMqOptions>(name)
@@ -72,7 +75,7 @@ namespace Orleans.Streaming
             bool useQueuePartitioning = RabbitMqOptions.DefaultUseQueuePartitioning,
             int numberOfQueues = RabbitMqOptions.DefaultNumberOfQueues)
         {
-            Configure<RabbitMqOptions>(ob => ob.Configure(options =>
+            this.Configure<RabbitMqOptions>(ob => ob.Configure(options =>
             {
                 options.HostName = host;
                 options.Port = port;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
 - start /B /WAIT %rabbitmq_installer_path% /S
 - ps: (Get-Service -Name RabbitMQ).Status
 
-version: 2.4.3.{build}
+version: 3.0.0.{build}
 assembly_info:
   patch: true
   file: AssemblyInfo.cs


### PR DESCRIPTION
Updated the projects to use the 3.0.0 interfaces for Orlean, as well as to use ASPNETCORE 3.0 where it can be for things like unit testing